### PR TITLE
avoid enum

### DIFF
--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DatePickerDialog.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/date/DatePickerDialog.java
@@ -19,6 +19,7 @@ package com.wdullaer.materialdatetimepicker.date;
 import android.animation.ObjectAnimator;
 import android.app.Activity;
 import android.app.Dialog;
+import android.support.annotation.IntDef;
 import android.support.v4.app.DialogFragment;
 import android.content.DialogInterface;
 import android.content.res.Configuration;
@@ -48,7 +49,10 @@ import com.wdullaer.materialdatetimepicker.HapticFeedbackController;
 import com.wdullaer.materialdatetimepicker.R;
 import com.wdullaer.materialdatetimepicker.TypefaceHelper;
 import com.wdullaer.materialdatetimepicker.Utils;
+import com.wdullaer.materialdatetimepicker.time.TimePickerDialog;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -62,10 +66,25 @@ import java.util.TimeZone;
 public class DatePickerDialog extends DialogFragment implements
         OnClickListener, DatePickerController {
 
-    public enum Version {
-        VERSION_1,
-        VERSION_2
-    }
+    /**
+     * Version 1 layout
+     * <p>
+     *      this is the original layout. It is based on the layout google used in the kitkat and early material design era
+     * </p>
+     */
+    public static final int VERSION_1 = 0;
+
+    /**
+     * Version 2 layout
+     * <p>
+     *     this layout is based on the guidelines google posted when launching android marshmallow. This is the default and still the most current design.
+     * </p>
+     */
+    public static final int VERSION_2 = 1;
+
+    @Retention(RetentionPolicy.SOURCE)
+    @IntDef({VERSION_1, VERSION_2})
+    public @interface Version{}
 
     private static final int UNINITIALIZED = -1;
     private static final int MONTH_AND_DAY_VIEW = 0;
@@ -139,7 +158,7 @@ public class DatePickerDialog extends DialogFragment implements
     private int mCancelResid = R.string.mdtp_cancel;
     private String mCancelString;
     private int mCancelColor = -1;
-    private Version mVersion;
+    private @DatePickerDialog.Version int mVersion;
     private TimeZone mTimezone;
     private DefaultDateRangeLimiter mDefaultLimiter = new DefaultDateRangeLimiter();
     private DateRangeLimiter mDateRangeLimiter = mDefaultLimiter;
@@ -207,7 +226,7 @@ public class DatePickerDialog extends DialogFragment implements
         mCalendar.set(Calendar.MONTH, monthOfYear);
         mCalendar.set(Calendar.DAY_OF_MONTH, dayOfMonth);
 
-        mVersion = Build.VERSION.SDK_INT < Build.VERSION_CODES.M ? Version.VERSION_1 : Version.VERSION_2;
+        mVersion = Build.VERSION.SDK_INT < Build.VERSION_CODES.M ? VERSION_1 : VERSION_2;
     }
 
     @Override
@@ -293,7 +312,7 @@ public class DatePickerDialog extends DialogFragment implements
             mCancelResid = savedInstanceState.getInt(KEY_CANCEL_RESID);
             mCancelString = savedInstanceState.getString(KEY_CANCEL_STRING);
             mCancelColor = savedInstanceState.getInt(KEY_CANCEL_COLOR);
-            mVersion = (Version) savedInstanceState.getSerializable(KEY_VERSION);
+            mVersion = parsingIntToVersion((int) savedInstanceState.getSerializable(KEY_VERSION));
             mTimezone = (TimeZone) savedInstanceState.getSerializable(KEY_TIMEZONE);
             mDateRangeLimiter = savedInstanceState.getParcelable(KEY_DATERANGELIMITER);
 
@@ -314,7 +333,7 @@ public class DatePickerDialog extends DialogFragment implements
 
         mDefaultLimiter.setController(this);
 
-        int viewRes = mVersion == Version.VERSION_1 ? R.layout.mdtp_date_picker_dialog : R.layout.mdtp_date_picker_dialog_v2;
+        int viewRes = mVersion == VERSION_1 ? R.layout.mdtp_date_picker_dialog : R.layout.mdtp_date_picker_dialog_v2;
         View view = inflater.inflate(viewRes, container, false);
         // All options have been set at this point: round the initial selection if necessary
         mCalendar = mDateRangeLimiter.setToNearestDate(mCalendar);
@@ -465,7 +484,7 @@ public class DatePickerDialog extends DialogFragment implements
 
         switch (viewIndex) {
             case MONTH_AND_DAY_VIEW:
-                if (mVersion == Version.VERSION_1) {
+                if (mVersion == VERSION_1) {
                     ObjectAnimator pulseAnimator = Utils.getPulseAnimator(mMonthAndDayView, 0.9f,
                             1.05f);
                     if (mDelayAnimation) {
@@ -496,7 +515,7 @@ public class DatePickerDialog extends DialogFragment implements
                 Utils.tryAccessibilityAnnounce(mAnimator, mSelectDay);
                 break;
             case YEAR_VIEW:
-                if (mVersion == Version.VERSION_1) {
+                if (mVersion == VERSION_1) {
                     ObjectAnimator pulseAnimator = Utils.getPulseAnimator(mYearView, 0.85f, 1.1f);
                     if (mDelayAnimation) {
                         pulseAnimator.setStartDelay(ANIMATION_DELAY);
@@ -530,7 +549,7 @@ public class DatePickerDialog extends DialogFragment implements
     private void updateDisplay(boolean announce) {
         mYearView.setText(YEAR_FORMAT.format(mCalendar.getTime()));
 
-        if (mVersion == Version.VERSION_1) {
+        if (mVersion == VERSION_1) {
             if (mDatePickerHeaderView != null) {
                 if (mTitle != null)
                     mDatePickerHeaderView.setText(mTitle.toUpperCase(Locale.getDefault()));
@@ -543,7 +562,7 @@ public class DatePickerDialog extends DialogFragment implements
             mSelectedDayTextView.setText(DAY_FORMAT.format(mCalendar.getTime()));
         }
 
-        if (mVersion == Version.VERSION_2) {
+        if (mVersion == VERSION_2) {
             mSelectedDayTextView.setText(VERSION_2_FORMAT.format(mCalendar.getTime()));
             if (mTitle != null)
                 mDatePickerHeaderView.setText(mTitle.toUpperCase(Locale.getDefault()));
@@ -896,7 +915,7 @@ public class DatePickerDialog extends DialogFragment implements
      *
      * @param version The version to use
      */
-    public void setVersion(Version version) {
+    public void setVersion(@DatePickerDialog.Version int version) {
         mVersion = version;
     }
 
@@ -1039,5 +1058,21 @@ public class DatePickerDialog extends DialogFragment implements
             mCallBack.onDateSet(DatePickerDialog.this, mCalendar.get(Calendar.YEAR),
                     mCalendar.get(Calendar.MONTH), mCalendar.get(Calendar.DAY_OF_MONTH));
         }
+    }
+
+    /**
+     * this method is for parsing int type data to version type data
+     * @param value int type
+     * @return version type data
+     */
+    private @DatePickerDialog.Version int parsingIntToVersion(int value){
+        switch (value){
+            case VERSION_1:
+                return VERSION_1;
+            case VERSION_2:
+                return VERSION_2;
+        }
+
+        throw new IllegalArgumentException("no version for this value, value = "+value+ ", at class"+getClass().getSimpleName());
     }
 }

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/time/CircleView.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/time/CircleView.java
@@ -65,7 +65,7 @@ public class CircleView extends View {
         mPaint.setAntiAlias(true);
 
         mIs24HourMode = controller.is24HourMode();
-        if (mIs24HourMode || controller.getVersion() != TimePickerDialog.Version.VERSION_1) {
+        if (mIs24HourMode || controller.getVersion() != TimePickerDialog.VERSION_1) {
             mCircleRadiusMultiplier = Float.parseFloat(
                     res.getString(R.string.mdtp_circle_radius_multiplier_24HourMode));
         } else {

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/time/RadialPickerLayout.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/time/RadialPickerLayout.java
@@ -173,7 +173,7 @@ public class RadialPickerLayout extends FrameLayout implements OnTouchListener {
         // Initialize the circle and AM/PM circles if applicable.
         mCircleView.initialize(context, mController);
         mCircleView.invalidate();
-        if (!mIs24HourMode && mController.getVersion() == TimePickerDialog.Version.VERSION_1) {
+        if (!mIs24HourMode && mController.getVersion() == TimePickerDialog.VERSION_1) {
             mAmPmCirclesView.initialize(context, mController, initialTime.isAM() ? AM : PM);
             mAmPmCirclesView.invalidate();
         }
@@ -435,11 +435,11 @@ public class RadialPickerLayout extends FrameLayout implements OnTouchListener {
     private Timepoint roundToValidTime(Timepoint newSelection, int currentItemShowing) {
         switch(currentItemShowing) {
             case HOUR_INDEX:
-                return mController.roundToNearest(newSelection, null);
+                return mController.roundToNearest(newSelection, 0);
             case MINUTE_INDEX:
-                return mController.roundToNearest(newSelection, Timepoint.TYPE.HOUR);
+                return mController.roundToNearest(newSelection, Timepoint.HOUR);
             default:
-                return mController.roundToNearest(newSelection, Timepoint.TYPE.MINUTE);
+                return mController.roundToNearest(newSelection, Timepoint.MINUTE);
         }
     }
 
@@ -718,7 +718,7 @@ public class RadialPickerLayout extends FrameLayout implements OnTouchListener {
                 mDoingMove = false;
                 mDoingTouch = true;
                 // If we're showing the AM/PM, check to see if the user is touching it.
-                if (!mIs24HourMode && mController.getVersion() == TimePickerDialog.Version.VERSION_1) {
+                if (!mIs24HourMode && mController.getVersion() == TimePickerDialog.VERSION_1) {
                     mIsTouchingAmOrPm = mAmPmCirclesView.getIsTouchingAmOrPm(eventX, eventY);
                 } else {
                     mIsTouchingAmOrPm = -1;

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/time/RadialSelectorView.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/time/RadialSelectorView.java
@@ -108,7 +108,7 @@ public class RadialSelectorView extends View {
 
         // Calculate values for the circle radius size.
         mIs24HourMode = controller.is24HourMode();
-        if (mIs24HourMode || controller.getVersion() != TimePickerDialog.Version.VERSION_1) {
+        if (mIs24HourMode || controller.getVersion() != TimePickerDialog.VERSION_1) {
             mCircleRadiusMultiplier = Float.parseFloat(
                     res.getString(R.string.mdtp_circle_radius_multiplier_24HourMode));
         } else {

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/time/RadialTextsView.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/time/RadialTextsView.java
@@ -123,7 +123,7 @@ public class RadialTextsView extends View {
         mHasInnerCircle = (innerTexts != null);
 
         // Calculate the radius for the main circle.
-        if (mIs24HourMode || controller.getVersion() != TimePickerDialog.Version.VERSION_1) {
+        if (mIs24HourMode || controller.getVersion() != TimePickerDialog.VERSION_1) {
             mCircleRadiusMultiplier = Float.parseFloat(
                     res.getString(R.string.mdtp_circle_radius_multiplier_24HourMode));
         } else {

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/time/TimePickerController.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/time/TimePickerController.java
@@ -24,7 +24,7 @@ public interface TimePickerController {
     /**
      * @return Version - The current version to render
      */
-    TimePickerDialog.Version getVersion();
+    @TimePickerDialog.Version int getVersion();
 
     /**
      * Request the device to vibrate
@@ -57,5 +57,5 @@ public interface TimePickerController {
      * @param type Timepoint.TYPE - whether we should round the hours, minutes or seconds
      * @return timepoint - the nearest valid timepoint
      */
-    Timepoint roundToNearest(Timepoint time, Timepoint.TYPE type);
+    Timepoint roundToNearest(Timepoint time, @Timepoint.type int type);
 }

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/time/TimePickerDialog.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/time/TimePickerDialog.java
@@ -19,6 +19,7 @@ package com.wdullaer.materialdatetimepicker.time;
 import android.animation.ObjectAnimator;
 import android.app.ActionBar.LayoutParams;
 import android.app.Dialog;
+import android.support.annotation.IntDef;
 import android.support.v4.app.DialogFragment;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -52,6 +53,8 @@ import com.wdullaer.materialdatetimepicker.TypefaceHelper;
 import com.wdullaer.materialdatetimepicker.Utils;
 import com.wdullaer.materialdatetimepicker.time.RadialPickerLayout.OnValueSelectedListener;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.text.DateFormatSymbols;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -66,10 +69,25 @@ public class TimePickerDialog extends DialogFragment implements
         OnValueSelectedListener, TimePickerController {
     private static final String TAG = "TimePickerDialog";
 
-    public enum Version {
-        VERSION_1,
-        VERSION_2
-    }
+    /**
+     * Version 1 layout
+     * <p>
+     *      this is the original layout. It is based on the layout google used in the kitkat and early material design era
+     * </p>
+     */
+    public static final int VERSION_1 = 0;
+
+    /**
+     * Version 2 layout
+     * <p>
+     *     this layout is based on the guidelines google posted when launching android marshmallow. This is the default and still the most current design.
+     * </p>
+     */
+    public static final int VERSION_2 = 1;
+
+    @Retention(RetentionPolicy.SOURCE)
+    @IntDef({VERSION_1, VERSION_2})
+    public @interface Version{}
 
     private static final String KEY_INITIAL_TIME = "initial_time";
     private static final String KEY_IS_24_HOUR_VIEW = "is_24_hour_view";
@@ -148,7 +166,7 @@ public class TimePickerDialog extends DialogFragment implements
     private int mCancelResid;
     private String mCancelString;
     private int mCancelColor;
-    private Version mVersion;
+    private @TimePickerDialog.Version int mVersion;
 
     // For hardware IME input.
     private char mPlaceholderText;
@@ -224,7 +242,7 @@ public class TimePickerDialog extends DialogFragment implements
         mOkColor = -1;
         mCancelResid = R.string.mdtp_cancel;
         mCancelColor = -1;
-        mVersion = Build.VERSION.SDK_INT < Build.VERSION_CODES.M ? Version.VERSION_1 : Version.VERSION_2;
+        mVersion = Build.VERSION.SDK_INT < Build.VERSION_CODES.M ? VERSION_1 : VERSION_2;
     }
 
     /**
@@ -495,13 +513,29 @@ public class TimePickerDialog extends DialogFragment implements
      * Set which layout version the picker should use
      * @param version The version to use
      */
-    public void setVersion(Version version) {
+    public void setVersion(@Version int version) {
         mVersion = version;
     }
 
     @Override
-    public Version getVersion() {
+    public @Version int getVersion() {
         return mVersion;
+    }
+
+    /**
+     * this method is for parsing int type data to version type data
+     * @param value int type
+     * @return version type data
+     */
+    private @Version int parsingIntToVersion(int value){
+        switch (value){
+            case VERSION_1:
+                return VERSION_1;
+            case VERSION_2:
+                return VERSION_2;
+        }
+
+        throw new IllegalArgumentException("no version for this value, value = "+value+ ", at class"+getClass().getSimpleName());
     }
 
     @Override
@@ -529,7 +563,7 @@ public class TimePickerDialog extends DialogFragment implements
             mCancelResid = savedInstanceState.getInt(KEY_CANCEL_RESID);
             mCancelString = savedInstanceState.getString(KEY_CANCEL_STRING);
             mCancelColor = savedInstanceState.getInt(KEY_CANCEL_COLOR);
-            mVersion = (Version) savedInstanceState.getSerializable(KEY_VERSION);
+            mVersion = parsingIntToVersion((int) savedInstanceState.getSerializable(KEY_VERSION));
         }
     }
 
@@ -537,7 +571,7 @@ public class TimePickerDialog extends DialogFragment implements
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
             Bundle savedInstanceState) {
 
-        int viewRes = mVersion == Version.VERSION_1 ? R.layout.mdtp_time_picker_dialog : R.layout.mdtp_time_picker_dialog_v2;
+        int viewRes = mVersion == VERSION_1 ? R.layout.mdtp_time_picker_dialog : R.layout.mdtp_time_picker_dialog_v2;
         View view = inflater.inflate(viewRes, container,false);
         KeyboardListener keyboardListener = new KeyboardListener();
         view.findViewById(R.id.mdtp_time_picker_dialog).setOnKeyListener(keyboardListener);
@@ -678,7 +712,7 @@ public class TimePickerDialog extends DialogFragment implements
             mAmTextView .setVisibility(View.GONE);
             mPmTextView.setVisibility(View.VISIBLE);
             mAmPmLayout.setOnClickListener(listener);
-            if (mVersion == Version.VERSION_2) {
+            if (mVersion == VERSION_2) {
                 mAmTextView.setText(mAmText);
                 mPmTextView.setText(mPmText);
                 mAmTextView.setVisibility(View.VISIBLE);
@@ -940,7 +974,7 @@ public class TimePickerDialog extends DialogFragment implements
     }
 
     private void updateAmPmDisplay(int amOrPm) {
-        if (mVersion == Version.VERSION_2) {
+        if (mVersion == VERSION_2) {
             if (amOrPm == AM) {
                 mAmTextView.setTextColor(mSelectedColor);
                 mPmTextView.setTextColor(mUnselectedColor);
@@ -1117,11 +1151,11 @@ public class TimePickerDialog extends DialogFragment implements
      * @return Timepoint - The nearest valid Timepoint
      */
     private Timepoint roundToNearest(@NonNull Timepoint time) {
-        return roundToNearest(time, null);
+        return roundToNearest(time, 0);
     }
 
     @Override
-    public Timepoint roundToNearest(@NonNull Timepoint time, @Nullable Timepoint.TYPE type) {
+    public Timepoint roundToNearest(@NonNull Timepoint time, @Nullable @Timepoint.type int type) {
 
         if(mMinTime != null && mMinTime.compareTo(time) > 0) return mMinTime;
 
@@ -1132,11 +1166,11 @@ public class TimePickerDialog extends DialogFragment implements
             for(Timepoint t : mSelectableTimes) {
                 // type == null: no restrictions
                 // type == HOUR: do not change the hour
-                if (type == Timepoint.TYPE.HOUR && t.getHour() != time.getHour()) continue;
+                if (type == Timepoint.HOUR && t.getHour() != time.getHour()) continue;
                 // type == MINUTE: do not change hour or minute
-                if (type == Timepoint.TYPE.MINUTE  && t.getHour() != time.getHour() && t.getMinute() != time.getMinute()) continue;
+                if (type == Timepoint.MINUTE  && t.getHour() != time.getHour() && t.getMinute() != time.getMinute()) continue;
                 // type == SECOND: cannot change anything, return input
-                if (type == Timepoint.TYPE.SECOND) return time;
+                if (type == Timepoint.SECOND) return time;
                 int newDistance = Math.abs(t.compareTo(time));
                 if (newDistance < currentDistance) {
                     currentDistance = newDistance;

--- a/library/src/main/java/com/wdullaer/materialdatetimepicker/time/Timepoint.java
+++ b/library/src/main/java/com/wdullaer/materialdatetimepicker/time/Timepoint.java
@@ -18,11 +18,11 @@ public class Timepoint implements Parcelable, Comparable<Timepoint> {
     private int minute;
     private int second;
 
-    public enum TYPE {
-        HOUR,
-        MINUTE,
-        SECOND
-    }
+    public static int HOUR = 1;
+    public static int MINUTE = 2;
+    public static int SECOND = 3;
+
+    public @interface type{}
 
     public Timepoint(Timepoint time) {
         this(time.hour, time.minute, time.second);

--- a/sample/src/main/java/com/wdullaer/datetimepickerexample/DatePickerFragment.java
+++ b/sample/src/main/java/com/wdullaer/datetimepickerexample/DatePickerFragment.java
@@ -68,7 +68,7 @@ public class DatePickerFragment extends Fragment implements DatePickerDialog.OnD
                 dpd.vibrate(vibrateDate.isChecked());
                 dpd.dismissOnPause(dismissDate.isChecked());
                 dpd.showYearPickerFirst(showYearFirst.isChecked());
-                dpd.setVersion(showVersion2.isChecked() ? DatePickerDialog.Version.VERSION_2 : DatePickerDialog.Version.VERSION_1);
+                dpd.setVersion(showVersion2.isChecked() ? DatePickerDialog.VERSION_2 : DatePickerDialog.VERSION_1);
                 if (modeCustomAccentDate.isChecked()) {
                     dpd.setAccentColor(Color.parseColor("#9C27B0"));
                 }

--- a/sample/src/main/java/com/wdullaer/datetimepickerexample/TimePickerFragment.java
+++ b/sample/src/main/java/com/wdullaer/datetimepickerexample/TimePickerFragment.java
@@ -69,7 +69,7 @@ public class TimePickerFragment extends Fragment implements TimePickerDialog.OnT
                 tpd.vibrate(vibrateTime.isChecked());
                 tpd.dismissOnPause(dismissTime.isChecked());
                 tpd.enableSeconds(enableSeconds.isChecked());
-                tpd.setVersion(showVersion2.isChecked() ? TimePickerDialog.Version.VERSION_2 : TimePickerDialog.Version.VERSION_1);
+                tpd.setVersion(showVersion2.isChecked() ? TimePickerDialog.VERSION_2 : TimePickerDialog.VERSION_1);
                 if (modeCustomAccentTime.isChecked()) {
                     tpd.setAccentColor(Color.parseColor("#9C27B0"));
                 }


### PR DESCRIPTION
Using enum will increase dex size and increase runtime memory allocation size.
reference: https://www.youtube.com/watch?v=Hzs6OBcvNQE

solution for replace enum is using intDef
 public static final int VERSION_1 = 0;
 public static final int VERSION_2 = 1;

@Retention(RetentionPolicy.SOURCE)
    @IntDef({VERSION_1, VERSION_2})
    public @interface Version{}